### PR TITLE
Add setup docs and update manifest link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Music Assistant can be operated as a complete standalone product but it is actua
 
 See here https://music-assistant.io/installation/
 
+For manual installation and configuration options see [SETUP.md](./SETUP.md).
+
 [repository-badge]: https://img.shields.io/badge/Add%20repository%20to%20my-Home%20Assistant-41BDF5?logo=home-assistant&style=for-the-badge
 [repository-url]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fhome-assistant-addon
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,48 @@
+# Setup Guide
+
+This guide explains how to install and run the Music Assistant Server manually.
+
+## Requirements
+- **Python 3.12 or newer**
+- **ffmpeg** version 6.1 or later must be available on your system.
+- **uv** package manager for installing Python dependencies.
+
+## Installation Steps
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/music-assistant/server.git
+   cd server
+   ```
+2. Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+3. Upgrade `pip` and install `uv`:
+   ```bash
+   pip install --upgrade pip uv
+   ```
+4. Install Music Assistant and its dependencies using `uv`:
+   ```bash
+   uv pip install -e .
+   ```
+   To enable the optional Music Insights provider run:
+   ```bash
+   uv pip install -e .[music-insights]
+   ```
+
+## Running the Server
+Start the server with the `mass` command:
+```bash
+mass
+```
+By default the configuration and database files are stored in `~/.musicassistant`. You can specify a different directory with:
+```bash
+mass --config /path/to/config
+```
+Additional useful options:
+- `--log-level <level>` – set logging verbosity (`info`, `warning`, `debug`, `verbose`, ...).
+- `--safe-mode` – start without loading any providers.
+
+## Next Steps
+Once the server is running, open the web interface on `http://<server-ip>:8095` and follow the onboarding steps to add providers and players.

--- a/music_assistant/providers/music_insights/manifest.json
+++ b/music_assistant/providers/music_insights/manifest.json
@@ -5,5 +5,5 @@
   "description": "Provides music recommendations, similar track suggestions, and semantic search capabilities based on audio embeddings and user interactions.",
   "codeowners": ["@ztripez"],
   "requirements": ["chromadb","transformers","torch","torchaudio","accelerate","bitsandbytes"],
-  "documentation": "Link to the documentation on the music-assistant.io helppage (may be added later)."
+  "documentation": "https://www.music-assistant.io/music-insights/"
 }


### PR DESCRIPTION
## Summary
- document manual setup instructions in new SETUP.md
- reference setup doc from README
- link Music Insights provider to proper docs

## Testing
- `pre-commit run --files README.md SETUP.md music_assistant/providers/music_insights/manifest.json` *(fails: check-case-conflict: not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiojellyfin')*

------
https://chatgpt.com/codex/tasks/task_e_684fc2d9e7048329a6d306f3e1305b04